### PR TITLE
(untested) try supporting multiple users

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -16,10 +16,17 @@
 		return count;
 	}
 
+	function getAtomFeedUrl() {
+		const url = new URL(window.location.href);
+		url.pathname += document.querySelector('link[type="application/atom+xml"]').getAttribute('href');
+		return url.toString().split('#')[0];
+	}
+	
 	function getAtomFeed() {
+		const atomFeedUrl = getAtomFeedUrl();
 		return new Promise((resolve) => {
 			const x = new XMLHttpRequest();
-			x.open('GET', 'https://mail.google.com/mail/feed/atom?_=' + new Date().getTime(), true);
+			x.open('GET', atomFeedUrl + '?_=' + new Date().getTime(), true);
 			x.setRequestHeader('Cache-Control', 'no-cache');
 			x.onreadystatechange = function () {
 				if (x.readyState == 4 && x.status == 200) {


### PR DESCRIPTION
This should change the way the atomFeedUrl in order to possibly support multiple users out of the box.

The new feed url would look something like this:
`https://mail.google.com/mail/u/0/feed/atom`