### PR TITLE
handle multiple google accounts

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -16,10 +16,10 @@
 		return count;
 	}
 
-	function getAtomFeed() {
+	function getAtomFeed(accountId) {
 		return new Promise((resolve) => {
 			const x = new XMLHttpRequest();
-			x.open('GET', 'https://mail.google.com/mail/feed/atom?_=' + new Date().getTime(), true);
+			x.open('GET', 'https://mail.google.com/mail/u/'+accountId+'/feed/atom?_=' + new Date().getTime(), true);
 			x.setRequestHeader('Cache-Control', 'no-cache');
 			x.onreadystatechange = function () {
 				if (x.readyState == 4 && x.status == 200) {
@@ -30,8 +30,22 @@
 		});
 	}
 
+	async function getLocalStorageValue(key) {
+    return new Promise((resolve, reject) => {
+        try {
+            chrome.storage.sync.get(key, function (value) {
+                resolve(value);
+            })
+        }
+        catch (ex) {
+            reject(ex);
+        }
+    });
+}
+
 	async function updateBadgeIcon() {
-		const feed = await getAtomFeed();
+		const options = await getLocalStorageValue("accountId");
+		const feed = await getAtomFeed(options["accountId"]);
 		const newUnreadCount = getUnreadCount(feed);
 		if (newUnreadCount < 0) {
 			return;

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -4,6 +4,12 @@
   "manifest_version": 2,
   "description": "Show badge notifications in the taskbar when using Gmail as an app",
   "homepage_url": "https://github.com/aberonni/gmail-app-badge-notification",
+  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": false
+  },
+  "permissions": ["storage"],
   "icons": {
     "16": "icons/icon16.png",
     "48": "icons/icon48.png",

--- a/src/options.html
+++ b/src/options.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+<head><title>My Options</title></head>
+<body>
+
+Account number.
+0 by default is the main account
+<label>
+  <input type="number" id="accountId">
+</label>
+
+<div id="status"></div>
+<button id="save">Save</button>
+
+<script src="options.js"></script>
+</body>
+</html>

--- a/src/options.js
+++ b/src/options.js
@@ -1,0 +1,28 @@
+// Saves options to chrome.storage
+function save_options() {
+  var accountId = document.getElementById('accountId').value;
+  chrome.storage.sync.set({
+    accountId: accountId
+  }, function() {
+    // Update status to let user know options were saved.
+    var status = document.getElementById('status');
+    status.textContent = 'Options saved.';
+    setTimeout(function() {
+      status.textContent = '';
+    }, 750);
+  });
+}
+
+// Restores select box and checkbox state using the preferences
+// stored in chrome.storage.
+function restore_options() {
+  // Use default value accountId = '0'
+  chrome.storage.sync.get({
+    accountId: '0',
+  }, function(items) {
+    document.getElementById('accountId').value = items.accountId;
+  });
+}
+document.addEventListener('DOMContentLoaded', restore_options);
+document.getElementById('save').addEventListener('click',
+    save_options);


### PR DESCRIPTION
Google allows to connect multiple google accounts to the same account. 
It switches between account with url params 
`https://mail.google.com/mail/u/0/feed/atom` for the default account and then `https://mail.google.com/mail/u/1/feed/atom` ... 

This pull-request add an option panel allowing to select witch account should be synced with the badge. 

![image](https://user-images.githubusercontent.com/5638195/111126391-f0f0a200-8572-11eb-956b-f55c1cd10f3a.png)
