### PR TITLE
Adjust match to restrict to just gmail.

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -12,7 +12,7 @@
   "content_scripts": [
     {
       "matches": [
-        "*://*.mail.google.com/*"
+        "*://*.mail.google.com/mail/*"
       ],
       "js": [
         "content.js"


### PR DESCRIPTION
closes #9 

The current match of `"*://*.mail.google.com/*"` was accidentally matching for both Mail and Chat.  This issue appears to have surfaced when the urls for chat where adjusted.

- https://mail.google.com/chat/u/0/
- https://mail.google.com/mail/u/0/#inbox

## Fix
- Adjust `matches` to only target `mail`

## Example
<img width="84" alt="IMG_8714" src="https://user-images.githubusercontent.com/229046/123497113-baa6d200-d5f9-11eb-83dd-9f44ff10ae0b.png">

