### PR TITLE
Use document.title instead of network polling

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,6 +1,12 @@
-Object.defineProperty(document, 'title', {
-  configurable: true,
-  set(v) {
-    navigator.setAppBadge((String(v).match(/\((\d+)\)/) || [])[1] | 0 || null);
-  }
-});
+(() => {
+  let desc = Object.getOwnPropertyDescriptor(Document.prototype, 'title');
+  Object.defineProperty(document, 'title', {
+    configurable: true,
+    set(v) {
+      let m = String(v).match(/Inbox(?: \((\d+)\)) -/);
+      if (m) navigator.setAppBadge((m[1]|0) || null);
+      desc.set.call(this, v);
+    },
+    get() { return desc.get.call(this); }
+  });
+})();

--- a/src/content.js
+++ b/src/content.js
@@ -1,46 +1,6 @@
-(() => {
-	let unreadCount;
-
-	function getUnreadCount(doc) {
-		if (!doc) {
-			return -1;
-		}
-		const fullcountElement = doc.querySelector('fullcount');
-		if (!fullcountElement) {
-			return -1;
-		}
-		const count = parseInt(fullcountElement.textContent);
-		if (isNaN(count)) {
-			return -1;
-		}
-		return count;
-	}
-
-	function getAtomFeed() {
-		return new Promise((resolve) => {
-			const x = new XMLHttpRequest();
-			x.open('GET', 'https://mail.google.com/mail/feed/atom?_=' + new Date().getTime(), true);
-			x.setRequestHeader('Cache-Control', 'no-cache');
-			x.onreadystatechange = function () {
-				if (x.readyState == 4 && x.status == 200) {
-					resolve(x.responseXML);
-				}
-			};
-			x.send(null);
-		});
-	}
-
-	async function updateBadgeIcon() {
-		const feed = await getAtomFeed();
-		const newUnreadCount = getUnreadCount(feed);
-		if (newUnreadCount < 0) {
-			return;
-		}
-		if (newUnreadCount !== unreadCount) {
-			unreadCount = newUnreadCount
-			navigator.setAppBadge(unreadCount);
-		}
-	}
-
-	setInterval(updateBadgeIcon, 1000);
-})();
+Object.defineProperty(document, 'title', {
+  configurable: true,
+  set(v) {
+    navigator.setAppBadge((String(v).match(/\((\d+)\)/) || [])[1] | 0 || null);
+  }
+});

--- a/src/content.js
+++ b/src/content.js
@@ -3,7 +3,7 @@
   Object.defineProperty(document, 'title', {
     configurable: true,
     set(v) {
-      let m = String(v).match(/Inbox(?: \((\d+)\)) -/);
+      let m = String(v).match(/Inbox(?: \((\d+)\))? -/);
       if (m) navigator.setAppBadge((m[1]|0) || null);
       desc.set.call(this, v);
     },


### PR DESCRIPTION
I was noticing a decent bit of bandwidth/cpu being consumed by this extension due to the 1-second interval in use.

This PR switches to a solution that intercepts Gmail setting `document.title = `, then detects the presence of `Inbox (123) -` to determine the number of unread messages. One perk of this approach is that it is instant.

As another perk, this fixes #5.