### PR TITLE
Multiple accounts

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -1,43 +1,78 @@
 (() => {
-    let unreadCount;
+  let unreadCount;
 
-    function getUnreadCount(doc) {
-        if (!doc) return -1;
-        const fullcountElement = doc.querySelector('fullcount');
-        if (!fullcountElement) return -1;
-        const count = parseInt(fullcountElement.textContent);
-        return isNaN(count) ? -1 : count;
+  function getUnreadCount(doc) {
+    if (!doc) return -1;
+    const fullcountElement = doc.querySelector("fullcount");
+    if (!fullcountElement) return -1;
+    const count = parseInt(fullcountElement.textContent);
+    return isNaN(count) ? -1 : count;
+  }
+
+  function getTitle(doc) {
+    if (!doc) return -1;
+    const titleElement = doc.querySelector("title");
+    if (!titleElement) return -1;
+    return titleElement.textContent;
+  }
+
+  // Fetch Gmail feed and parse unread count
+  async function getAtomFeed(label, accountNum) {
+    const url = `https://mail.google.com/mail/u/${accountNum}/feed/atom${
+      label ? `/${label}` : ""
+    }?_=${new Date().getTime()}`;
+
+    return fetch(url, {
+      method: "GET",
+      headers: { "Cache-Control": "no-cache" },
+    })
+      .then((response) => response.text())
+      .then((text) => {
+        const parser = new DOMParser();
+        return parser.parseFromString(text, "application/xml");
+      })
+      .catch((err) => {
+        console.error("Error fetching Atom feed:", err);
+        return null;
+      });
+  }
+
+  async function updateBadgeIcon(label) {
+    let newUnreadCount = 0;
+    const checkedAccounts = [];
+
+    // kind of a hack -
+    // since we don't know how many email accounts
+    // let's check up to 10, and stop once we have
+    // no new ones
+    for (let i = 0; i < 10; i++) {
+      const feed = await getAtomFeed(label, i);
+      const emailTitle = getTitle(feed);
+
+      // don't keep counting once we have checked all the accounts
+      if (checkedAccounts.includes(emailTitle)) {
+        break;
+      }
+
+      checkedAccounts.push(emailTitle);
+      newUnreadCount += getUnreadCount(feed);
     }
 
-    // Fetch Gmail feed and parse unread count
-    async function getAtomFeed(label) {
-        const url = `https://mail.google.com/mail/feed/atom${label ? `/${label}` : ''}?_=${new Date().getTime()}`;
-        return fetch(url, { method: 'GET', headers: { 'Cache-Control': 'no-cache' } })
-            .then(response => response.text())
-            .then(text => {
-                const parser = new DOMParser();
-                return parser.parseFromString(text, 'application/xml');
-            })
-            .catch(err => {
-                console.error('Error fetching Atom feed:', err);
-                return null;
-            });
+    if (newUnreadCount < 0) return;
+
+    if (newUnreadCount !== unreadCount) {
+      unreadCount = newUnreadCount;
+      navigator.setAppBadge(unreadCount);
     }
+  }
 
-    async function updateBadgeIcon() {
-        chrome.storage.sync.get({ label: '' }, async ({ label }) => {
-            const feed = await getAtomFeed(label);
-            const newUnreadCount = getUnreadCount(feed);
-            if (newUnreadCount < 0) return;
+  chrome.storage.sync.get(
+    { label: "", pollingInterval: 10000 },
+    async ({ label, pollingInterval }) => {
+      setInterval(() => updateBadgeIcon(label), 10000);
 
-            if (newUnreadCount !== unreadCount) {
-                unreadCount = newUnreadCount;
-                navigator.setAppBadge(unreadCount); 
-            }
-        });
+      // initial
+      updateBadgeIcon(label);
     }
-
-    setInterval(updateBadgeIcon, 1000);
-
-    updateBadgeIcon();
+  );
 })();

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Gmail app badge notification",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "manifest_version": 3,
   "description": "Show badge notifications in the taskbar when using Gmail as an app",
   "homepage_url": "https://github.com/aberonni/gmail-app-badge-notification",


### PR DESCRIPTION
Added support for multiple Gmail accounts.  In `updateBadgeIcon` we loop through up to 10 atomfeed accounts (logged in Google accounts) and tally up the unread count.

Changed the polling interval to 10 sec, because it felt fast enough and it feels fairly expensive to poll more frequently.  Probably should move polling interval to an optional user config, if someone wants to add that feature.
