### PR TITLE
[ISSUES-28] - fix(count): Revert count and map smart labels

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -3,8 +3,10 @@
 
     function getUnreadCount(doc) {
         if (!doc) return -1;
-        const entries = doc.querySelectorAll('entry');
-        return entries.length;
+        const fullcountElement = doc.querySelector('fullcount');
+        if (!fullcountElement) return -1;
+        const count = parseInt(fullcountElement.textContent);
+        return isNaN(count) ? -1 : count;
     }
 
     // Fetch Gmail feed and parse unread count

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Gmail app badge notification",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "manifest_version": 3,
   "description": "Show badge notifications in the taskbar when using Gmail as an app",
   "homepage_url": "https://github.com/aberonni/gmail-app-badge-notification",

--- a/src/options.js
+++ b/src/options.js
@@ -13,6 +13,8 @@ function saveOptions(event) {
     const label = document.getElementById('label').value.trim();
 
     // Define a mapping of labels to their transformed values
+    // the transformed values are the ones used and displayed in Gmail's Atom feed
+    // the original labels are the ones still used by good ol' Gmail although they updated the UI to the new values
     const labelMap = {
         'important': '^iim',
         'personal': '^smartlabel_personal',
@@ -24,7 +26,6 @@ function saveOptions(event) {
         'receipt': '^smartlabel_receipt',
     };
 
-    // Transform label using the mapping, default to original label
     const finalLabel = labelMap[label.toLowerCase()] || label;
 
     chrome.storage.sync.set({ label: finalLabel }, () => {

--- a/src/options.js
+++ b/src/options.js
@@ -12,8 +12,20 @@ function saveOptions(event) {
     event.preventDefault();
     const label = document.getElementById('label').value.trim();
 
-    // Transform "important" to "^iim" without reassigning label
-    const finalLabel = label.toLowerCase() === 'important' ? '^iim' : label;
+    // Define a mapping of labels to their transformed values
+    const labelMap = {
+        'important': '^iim',
+        'personal': '^smartlabel_personal',
+        'social': '^smartlabel_social',
+        'promotions': '^smartlabel_promo',
+        'updates': '^smartlabel_notification',
+        'forums': '^smartlabel_group',
+        'newsletter': '^smartlabel_newsletter',
+        'receipt': '^smartlabel_receipt',
+    };
+
+    // Transform label using the mapping, default to original label
+    const finalLabel = labelMap[label.toLowerCase()] || label;
 
     chrome.storage.sync.set({ label: finalLabel }, () => {
         const status = document.getElementById('status');
@@ -21,6 +33,7 @@ function saveOptions(event) {
         setTimeout(() => status.classList.remove('show'), 2000);
     });
 }
+
 
 
 document.addEventListener('DOMContentLoaded', restoreOptions);

--- a/src/options.js
+++ b/src/options.js
@@ -36,6 +36,5 @@ function saveOptions(event) {
 }
 
 
-
 document.addEventListener('DOMContentLoaded', restoreOptions);
 document.getElementById('settings-form').addEventListener('submit', saveOptions);


### PR DESCRIPTION
A previous change broke the count and could only count up to 20 emails because that's what the atom feed is limited to.

The fullcount counts all correct emails.

This change does:

- reverts back to the fullcount to fix the bug
- map the smart labels to avoid the issue where if you use the pre-built google categories it was giving a fullcount as 0